### PR TITLE
VSC devcontainer customizations

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,40 +12,43 @@
 
 	"workspaceFolder": "/home/irisowner/dev",
 
-	// This provides the elements of the connection object which require different values when connecting to the workspace within the container,
-	// versus those in .vscode/settings.json which apply when operating locally on the workspace files.
-	// We define and use a `server` so that (a) a user-level `objectscript.conn.server` properly doesn't override us, and (b) so InterSystems
-	// Server Manager can also be used.
-	"settings": {
-		"objectscript.conn" :{
-			"server": "devcontainer",
-			"active": true,
-		},
-		"intersystems.servers": {
-			"devcontainer": {
-				"username": "SuperUser",
-				"password": "SYS",
-				"webServer": {
-					"scheme": "http",
-					"host": "127.0.0.1",
-					"port": 52773
+	"customizations": {
+		"vscode": {
+			// This provides the elements of the connection object which require different values when connecting to the workspace within the container,
+			// versus those in .vscode/settings.json which apply when operating locally on the workspace files.
+			// We define and use a `server` so that (a) a user-level `objectscript.conn.server` properly doesn't override us, and (b) so InterSystems
+			// Server Manager can also be used.
+			"settings": {
+				"objectscript.conn" :{
+					"server": "devcontainer",
+					"active": true
 				},
+				"intersystems.servers": {
+					"devcontainer": {
+						"username": "SuperUser",
+						"password": "SYS",
+						"webServer": {
+							"scheme": "http",
+							"host": "127.0.0.1",
+							"port": 52773
+						}
+					}
+				},
+				"python.defaultInterpreterPath":"/usr/irissys/bin/irispython"
 			},
-		},
-		"python.defaultInterpreterPath":"/usr/irissys/bin/irispython"
-	},
-
-	// Add the IDs of extensions we want installed when the container is created.
-	// Currently (March 2022) `intersystems.language-server` fails to run within the container (alpine platform).
-	// Issue is probably https://github.com/intersystems/language-server/issues/185 and/or https://github.com/intersystems/language-server/issues/32
-	// Crash gets reported to the user, after which `intersystems-community.vscode-objectscript` falls back to
-	// using its TextMate grammar for code coloring.
-	"extensions": [
-		"ms-python.python",
-		"ms-python.vscode-pylance",
-		"intersystems-community.vscode-objectscript",
-        "intersystems.language-server",
-		"intersystems-community.servermanager",
-		"ms-vscode.docker"
-	],
+			// Add the IDs of extensions we want installed when the container is created.
+			// Currently (March 2022) `intersystems.language-server` fails to run within the container (alpine platform).
+			// Issue is probably https://github.com/intersystems/language-server/issues/185 and/or https://github.com/intersystems/language-server/issues/32
+			// Crash gets reported to the user, after which `intersystems-community.vscode-objectscript` falls back to
+			// using its TextMate grammar for code coloring.
+			"extensions": [
+				"ms-python.python",
+				"ms-python.vscode-pylance",
+				"intersystems-community.vscode-objectscript",
+				"intersystems.language-server",
+				"intersystems-community.servermanager",
+				"ms-vscode.docker"
+			]
+		}
+	}
 }


### PR DESCRIPTION
- moved vscode settings and extensions to customizations property as per [Visual Studio Code specific properties go under vscode inside customizations](https://containers.dev/supporting)
- removed trailing commas